### PR TITLE
srtp: fix for possible sequence number corruption on wrap around boun…

### DIFF
--- a/src/srtp/replay.c
+++ b/src/srtp/replay.c
@@ -10,9 +10,9 @@
 #include "srtp.h"
 
 
-enum {
-	SRTP_WINDOW_SIZE = 64
-};
+#ifndef SRTP_WINDOW_SIZE
+#define SRTP_WINDOW_SIZE  (64)  /**< Maximum number of packets in replay buffer */
+#endif
 
 
 void srtp_replay_init(struct replay *replay)

--- a/src/srtp/srtp.c
+++ b/src/srtp/srtp.c
@@ -151,6 +151,7 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 	size_t start;
 	uint64_t ix;
 	int err;
+	int diff;
 
 	if (!srtp || !mb)
 		return EINVAL;
@@ -168,7 +169,8 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 		return err;
 
 	/* Roll-Over Counter (ROC) */
-	if (seq_diff(strm->s_l, hdr.seq) <= -32768) {
+	diff = seq_diff(strm->s_l, hdr.seq);
+	if (diff <= -32768) {
 		strm->roc++;
 		strm->s_l = 0;
 	}
@@ -211,7 +213,7 @@ int srtp_encrypt(struct srtp *srtp, struct mbuf *mb)
 			return err;
 	}
 
-	if (hdr.seq > strm->s_l)
+    if (diff > 0 && (strm->roc == 0 || diff < 32768))
 		strm->s_l = hdr.seq;
 
 	mb->pos = start;


### PR DESCRIPTION
We encountered and fixed a bug in libre:
Assume we protect with SRTP a sequence of packets with following sequence numbers:
..., 65533, 65535, 0, 1, 65534, 2, ...
Sequence is a little bit out of order, and roc (roll over counter) should increment by 1.
The issue was that it eventually incremented by 2:
SN 0: roc++; s_l = 0
SN 1: s_l = 1
SN 65534: (hdr.seq > strm->s_l) => s_l = 65534
SN 2: roc++; s_l = 2

That led to incorrect "ix" calculation,then incorrect authentication tag was formed, then receiver (i.e. web browser based on libSRTP) failed to unprotect all subsequent packets with err=7 (auth error), stream was frozen.